### PR TITLE
Make Message a proper IndexedSeq[ByteString] to avoid manual overriding of methods

### DIFF
--- a/src/main/scala/zeromq/Message.scala
+++ b/src/main/scala/zeromq/Message.scala
@@ -1,15 +1,18 @@
 package zeromq
 
 import akka.util.ByteString
+import scala.collection.IndexedSeqLike
+import scala.collection.mutable.{ArrayBuffer, Builder}
 
-class Message(parts: ByteString*) extends IndexedSeq[ByteString] {
-  private val vector = Vector(parts: _*)
+class Message(parts: ByteString*) extends IndexedSeq[ByteString] with IndexedSeqLike[ByteString, Message] {
+  private val underlying = parts.toIndexedSeq
 
-  def apply(idx: Int) = vector(idx)
+  override def apply(idx: Int) = underlying(idx)
 
-  def length = vector.length
+  override def length = underlying.length
 
-  override def tail = Message(vector.tail: _*)
+  override def newBuilder: Builder[ByteString, Message] = 
+    ArrayBuffer.empty[ByteString].mapResult(Message.apply)
 }
 
 object Message {


### PR DESCRIPTION
This pull request makes Message a proper IndexedSeq[ByteString] collection. With this change you don't have to override methods like tail/filter/drop since the Message concrete type will be preserved.

More info: http://www.scala-lang.org/docu/files/collections-api/collections-impl_0.html

Example:

``` scala
val m = Message(ByteString("one"), ByteString("two"), ByteString("three"))

scala> m.tail
Message(ByteString(116, 119, 111), ByteString(116, 104, 114, 101, 101))

scala> m.drop(1)
Message(ByteString(116, 119, 111), ByteString(116, 104, 114, 101, 101))

scala> m.filter { _ == ByteString("one") }
Message(ByteString(111, 110, 101))
```
