### PR TITLE
Restore Travis CI configuration file, and add setup script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+ language: scala
+ scala:
+   - "2.10.3"
+ jdk:
+   - oraclejdk7
+   - openjdk7
+   - openjdk6
+ before_script:
+   - sh src/test/resources/setup_travis.sh
+ env:
+   - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # scala-zeromq
 
+[![Build Status](https://travis-ci.org/mDialog/scala-zeromq.svg?branch=master)](https://travis-ci.org/mDialog/scala-zeromq)
+
 scala-zeromq facilitates communication using the [ZeroMQ](http://zeromq.org)
 messaging library. ZeroMQ is a message-oriented socket communication library that
 supports several high-level messaging patterns, including request-reply,

--- a/src/test/resources/setup_travis.sh
+++ b/src/test/resources/setup_travis.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Install ZeroMQ
+wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
+tar -xzf zeromq-4.0.4.tar.gz
+cd zeromq-4.0.4
+./configure
+make
+sudo make install
+cd ../
+
+# Install JZMQ
+git clone https://github.com/zeromq/jzmq.git
+cd jzmq
+./autogen.sh
+./configure
+make
+sudo make install
+cd ../
+
+# Replace jar file
+rm -f lib/zmq.jar
+cp /usr/local/share/java/zmq.jar lib/


### PR DESCRIPTION
Using before_script, setup ZeroMQ and JZMQ.

I have confirmed the almost all case success and one case failure at my repository.
https://travis-ci.org/zaneli/scala-zeromq/builds/23945403

> should raise error if connect does not succeed **\* FAILED ***
> Expected exception org.zeromq.ZMQException to be thrown, but no exception was thrown. (SocketRefSpec.scala:48)

I'm sorry but I can't understand this cause.
(caused by the difference in version of ZeroMQ or JZMQ?
 my setup script is bad?
 or, test code is wrong?)

I hope the Travis CI environment and test result make you resolve the problem.
