### PR TITLE
Add zeromq.maximum-sockets setting

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,6 +6,9 @@ zeromq {
   # how long to wait for new socket
   new-socket-timeout = 2000ms
 
+	# maximum numbers of sockets
+	maximum-sockets = 16384
+
   poll-interrupt-socket = "inproc://scala-zeromq-poll-interrupt"
 
   socket-manager-dispatcher {

--- a/src/main/scala/zeromq/ZeroMQExtension.scala
+++ b/src/main/scala/zeromq/ZeroMQExtension.scala
@@ -16,6 +16,9 @@ object ZeroMQExtension extends ExtensionId[ZeroMQExtension] with ExtensionIdProv
 class ZeroMQExtension(val system: ActorSystem) extends Extension {
 
   private val zmqContext = ZMQ.context(1)
+
+  zmqContext.setMaxSockets(system.settings.config.getInt("zeromq.maximum-sockets"))
+
   system.registerOnTermination {
     zmqContext.term
   }


### PR DESCRIPTION
Add configuration for the maximum number of sockets allowed. The context object that scala-zeromq uses for all sockets has a default maximum of 1024 sockets, which is both configurable and increased to a default of 16384 sockets with this change.
