### PR TITLE
Fixed socket creation timeouts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
+
 name := "scala-zeromq"
 
 organization := "com.mdialog"
 
-version := "1.1.0"
+version := "1.1.1"
 
 scalaVersion := "2.11.0"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,13 +1,13 @@
 
 zeromq {
   # zeromq poller timeout
-  poll-timeout = 10s
+  poll-timeout = 1s
 
   # how long to wait for new socket
   new-socket-timeout = 2000ms
 
-	# maximum numbers of sockets
-	maximum-sockets = 16384
+  # maximum numbers of sockets
+  maximum-sockets = 16384
 
   poll-interrupt-socket = "inproc://scala-zeromq-poll-interrupt"
 


### PR DESCRIPTION
With poll-timeout >  new-socket-timeout :  In ZeroMQExtension if a socket creation is attempted before the initialization of the PUB/SUB sockets used to send interrupts, the SocketManager poller.poll (line59) will block the Actor thread and prevent any socket creation (NewSocket). 

Due to the fact that actorOf[SocketManager] is async, Tests were randomly passing since SocketManager was receiving NewSocket before its Poll message sent at initialization. 
