### PR TITLE
Java compatibility functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
  language: scala
+ dist: trusty
+ sudo: true
  scala:
-   - "2.10.4"
-   - "2.11.0"
+   - "2.11.7"
  jdk:
    - oraclejdk7
-   - openjdk7
-   - openjdk6
+   - oraclejdk8
+   - openjdk8
  before_script:
    - sh src/test/resources/setup_travis.sh
+ before_install:
+   - cat /etc/hosts
  env:
    - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+ addons:
+   #workaround for openjdk buffer overflow
+   hostname: dummy

--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ immutable handle called a SocketRef. Under the hood, scala-zeromq uses
 [Akka](http://akka.io) to ensure all socket interactions are handled safely and
 efficiently.
 
-**Requires libzmq (v2.1.0 or greater) and either
-[JZMQ](https://github.com/zeromq/jzmq) or
-[zeromq-scala-binding](https://github.com/valotrading/zeromq-scala-binding)**,
-neither is included automatically.
+**Requires libzmq (v2.1.0 or greater) and [JZMQ](https://github.com/zeromq/jzmq)**,
+neither of which is included automatically. See [Dependencies](#Dependencies).
 
 ## Using
 
@@ -119,6 +117,29 @@ socket actor.
 Close the socket by sending a PoisonPill to the socket actor.
 
     pullSocket ! PoisonPill
+    
+### Using with Akka (Java)
+
+While not as pretty, scala-zeromq can be used by akka written in Java as well. It looks a bit like this:
+
+    ActorRef subscriber = zmq.newSocketJ(SocketType.Sub$.MODULE$, new Listener(theListener), new Connect(endpoint), package$.MODULE$.SubscribeAll());
+
+See JavaUsageSuite.java for a full example.
+
+## <a name="Dependencies"></a>Dependencies
+
+### JZMQ
+
+JZMQ is a required package that contains java bindings for the native zeromq binaries. To include in your project you should do one of
+
+* [Build and install from source](https://github.com/zeromq/jzmq#building-and-installing-jzmq) (most customizable and current).
+* Include a [package dependency on JZMQ](http://search.maven.org/#artifactdetails|org.zeromq|jzmq|3.1.0|jar) from maven central (easiest).
+
+The package dependency is not included automatically so that you can build your own if you wish.
+
+### libzmq
+
+libzmq is the native zeromq library which is required. It must be built and installed for your particular platform. Instructions can be [found here](http://zeromq.org/intro:get-the-software).
 
 ## Documentation
 
@@ -134,6 +155,6 @@ Fork the project, add tests if possible and send a pull request.
 
 ## Contributors
 
-Chris Dinn, Sebastian Hubbard
+Chris Dinn, Sebastian Hubbard, Jason Goodwin, Luke Palmer
 
-**©2013 mDialog Corp. All rights reserved.**
+**©2016 mDialog Corp. All rights reserved.**

--- a/build.sbt
+++ b/build.sbt
@@ -5,23 +5,21 @@ organization := "com.mdialog"
 
 version := "1.1.1"
 
-scalaVersion := "2.11.0"
-
-crossScalaVersions := Seq("2.10.4", "2.11.0")
+scalaVersion := "2.11.7"
 
 parallelExecution := false
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:postfixOps")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.3.2",
-  "org.scalatest" %% "scalatest" % "2.1.3" % "test",
-  "com.typesafe.akka" %% "akka-testkit" % "2.3.2" % "test"
+  "com.typesafe.akka" %% "akka-actor" % "2.3.14",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+  "com.typesafe.akka" %% "akka-testkit" % "2.3.14" % "test",
+  "com.novocode" % "junit-interface" % "0.11" % "test"
 )
 
 resolvers ++= Seq(
- //   "Sonatype (releases)" at "https://oss.sonatype.org/content/repositories/releases/",
-    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+  "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
 publishTo <<= version { (v: String) =>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,6 +9,12 @@ zeromq {
   # maximum numbers of sockets
   maximum-sockets = 16384
 
+  # how the socket handler waits for native parameter or option calls to complete
+  socket-handler-timeout = 500ms
+
+  # how long socket ref waits for the socket to complete requests
+  socket-ref-timeout = 1000ms
+
   poll-interrupt-socket = "inproc://scala-zeromq-poll-interrupt"
 
   socket-manager-dispatcher {

--- a/src/main/scala/zeromq/Message.scala
+++ b/src/main/scala/zeromq/Message.scala
@@ -1,8 +1,10 @@
 package zeromq
 
 import akka.util.ByteString
-import scala.collection.IndexedSeqLike
-import scala.collection.mutable.{ ArrayBuffer, Builder }
+
+import scala.annotation.varargs
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.{IndexedSeqLike, mutable}
 
 class Message(parts: ByteString*) extends IndexedSeq[ByteString] with IndexedSeqLike[ByteString, Message] {
   private val underlying = parts.toIndexedSeq
@@ -11,11 +13,12 @@ class Message(parts: ByteString*) extends IndexedSeq[ByteString] with IndexedSeq
 
   override def length = underlying.length
 
-  override def newBuilder: Builder[ByteString, Message] =
+  override def newBuilder: mutable.Builder[ByteString, Message] =
     ArrayBuffer.empty[ByteString].mapResult(Message.apply)
 }
 
 object Message {
+  @varargs
   def apply(parts: ByteString*) = new Message(parts: _*)
 
   def unapplySeq(message: Message) = IndexedSeq.unapplySeq(message)

--- a/src/main/scala/zeromq/Params.scala
+++ b/src/main/scala/zeromq/Params.scala
@@ -99,3 +99,6 @@ case class ReceiveBufferSize(value: Long) extends SocketOption
 object ReceiveBufferSize extends SocketOptionQuery
 
 object FileDescriptor extends SocketOptionQuery
+
+case class Conflate(value: Boolean) extends SocketOption
+object Conflate extends SocketOptionQuery

--- a/src/main/scala/zeromq/Socket.scala
+++ b/src/main/scala/zeromq/Socket.scala
@@ -88,6 +88,7 @@ private[zeromq] abstract class Socket(val socket: ZMQ.Socket, val poller: ZMQ.Po
       case MulticastHops(value)        ⇒ socket.setMulticastHops(value)
       case SendBufferSize(value)       ⇒ socket.setSendBufferSize(value)
       case ReceiveBufferSize(value)    ⇒ socket.setReceiveBufferSize(value)
+      case Conflate(value)             ⇒ socket.setConflate(value)
     }
 
   def getSocketOption(query: SocketOptionQuery) =
@@ -109,6 +110,7 @@ private[zeromq] abstract class Socket(val socket: ZMQ.Socket, val poller: ZMQ.Po
       case SendBufferSize       ⇒ socket.getSendBufferSize
       case ReceiveBufferSize    ⇒ socket.getReceiveBufferSize
       case FileDescriptor       ⇒ socket.getFD
+      case Conflate             ⇒ socket.getConflate
     }
 
   def close {

--- a/src/main/scala/zeromq/SocketHandler.scala
+++ b/src/main/scala/zeromq/SocketHandler.scala
@@ -1,10 +1,10 @@
 package zeromq
 
+import java.util.concurrent.TimeUnit
+
 import akka.actor._
-import akka.pattern.{ ask, pipe }
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import akka.util.{ ByteString, Timeout }
+import akka.pattern.{ask, pipe}
+import akka.util.Timeout
 
 private[zeromq] object SocketHandler {
   def apply(socketManager: ActorRef, pollInterrupter: ActorRef, listener: Option[ActorRef]): Props =
@@ -12,9 +12,10 @@ private[zeromq] object SocketHandler {
 }
 
 private[zeromq] class SocketHandler(manager: ActorRef, pollInterrupter: ActorRef, var listener: Option[ActorRef]) extends Actor {
+
   import context.dispatcher
 
-  implicit val timeout = Timeout(500.millis)
+  implicit val timeout = Timeout(context.system.settings.config.getDuration("zeromq.new-socket-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
 
   def receive = {
     case message: Message ⇒
@@ -34,15 +35,15 @@ private[zeromq] class SocketHandler(manager: ActorRef, pollInterrupter: ActorRef
       if (listener == Some(l)) listener = None
 
     case param: SocketParam ⇒
-      manager ? (self, param) pipeTo sender
+      manager ?(self, param) pipeTo sender
       pollInterrupter ! Interrupt
 
     case query: SocketOptionQuery ⇒
-      manager ? (self, query) pipeTo sender
+      manager ?(self, query) pipeTo sender
       pollInterrupter ! Interrupt
   }
 
-  override def postStop: Unit = notifyListener(Closed)
-
   private def notifyListener(message: Any): Unit = listener map (_ ! message)
+
+  override def postStop: Unit = notifyListener(Closed)
 }

--- a/src/test/java/zeromq/JavaUsageSuite.java
+++ b/src/test/java/zeromq/JavaUsageSuite.java
@@ -1,0 +1,51 @@
+package zeromq;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import akka.testkit.SocketUtil;
+import akka.util.ByteString;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test that we can successfully use the library from java
+ */
+public class JavaUsageSuite {
+    static ActorSystem system;
+    static ZeroMQExtension zmq;
+
+    @BeforeClass
+    public static void setup() {
+        system = ActorSystem.create();
+        zmq = new ZeroMQExtension(system);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        JavaTestKit.shutdownActorSystem(system);
+        system = null;
+    }
+
+    @Test
+    public void JavaAPI() {
+        new JavaTestKit(system) {{
+            String endpoint = "tcp:/" + SocketUtil.temporaryServerAddress(SocketUtil.temporaryServerAddress$default$1(), SocketUtil.temporaryServerAddress$default$2());
+            ActorRef publisher = zmq.newSocketJ(SocketType.Pub$.MODULE$, new Bind(endpoint));
+            ActorRef subscriber = zmq.newSocketJ(SocketType.Sub$.MODULE$, new Listener(getRef()), new Connect(endpoint), package$.MODULE$.SubscribeAll());
+
+            publisher.tell(Message$.MODULE$.apply(ByteString.fromString("hello world")), ActorRef.noSender());
+            assertThat(expectMsgClass(FiniteDuration.apply(10, TimeUnit.SECONDS), Message.class).apply(0).utf8String(), equalTo("hello world"));
+
+            system.stop(subscriber);
+            system.stop(publisher);
+        }};
+    }
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+zeromq {
+  # set some relatively high timeouts to prevent test failures on busy travis machines
+  socket-handler-timeout = 4s
+  socket-ref-timeout = 6s
+  new-socket-timeout = 8s
+}

--- a/src/test/resources/setup_travis.sh
+++ b/src/test/resources/setup_travis.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 
 # Install ZeroMQ
-wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
-tar -xzf zeromq-4.0.4.tar.gz
-cd zeromq-4.0.4
-./configure
+wget http://download.zeromq.org/zeromq-4.1.4.tar.gz
+tar -xzf zeromq-4.1.4.tar.gz
+cd zeromq-4.1.4
+./configure --without-libsodium
 make
 sudo make install
 cd ../
 
 # Install JZMQ
 git clone https://github.com/zeromq/jzmq.git
-cd jzmq
+cd jzmq/jzmq-jni
 ./autogen.sh
 ./configure
 make
 sudo make install
-cd ../
+cd ../..
 
 # Add jar file
 mkdir lib

--- a/src/test/scala/zeromq/SocketRefSpec.scala
+++ b/src/test/scala/zeromq/SocketRefSpec.scala
@@ -1,11 +1,13 @@
 package zeromq
 
-import org.scalatest.FunSpec
-import org.zeromq.ZMQException
-import akka.util.ByteString
-import scala.concurrent.{ Await, Future, ExecutionContext }
-import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
+
+import akka.util.ByteString
+import org.scalatest.FunSpec
+import org.zeromq.{ZMQ, ZMQException}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class SocketRefSpec extends FunSpec {
 
@@ -157,7 +159,11 @@ class SocketRefSpec extends FunSpec {
       push.setSocketOption(Rate(100))
 
       assert(push.getSocketOption(Rate) === 100)
+
+      push.setSocketOption(Conflate(true))
+      assert(push.getSocketOption(Conflate) === {
+        if (ZMQ.getMajorVersion >= 4) true else false
+      })
     }
   }
-
 }

--- a/src/test/scala/zeromq/ZeroMQExtensionSpec.scala
+++ b/src/test/scala/zeromq/ZeroMQExtensionSpec.scala
@@ -1,14 +1,12 @@
-
 package zeromq
 
-import language.postfixOps
-
-import org.scalatest.{ FunSpecLike, MustMatchers }
-import akka.testkit.{ TestProbe, TestKit }
+import akka.actor.{Actor, ActorRef, ActorSystem, Cancellable}
+import akka.testkit.{SocketUtil, TestKit, TestProbe}
+import akka.util.{ByteString, Timeout}
+import org.scalatest.{FunSpecLike, MustMatchers}
 
 import scala.concurrent.duration._
-import akka.util.{ ByteString, Timeout }
-import akka.actor.{ Actor, ActorSystem, ActorRef, Cancellable }
+import scala.language.postfixOps
 
 // Much credit goes to akka-zeromq (https://github.com/akka/akka) for the 
 // contents of this file.
@@ -21,8 +19,7 @@ class ZeroMQExtensionSpec extends TestKit(ActorSystem("ZeroMQExtensionSpec")) wi
 
   describe("ZeroMQExtension") {
     it("should support pub-sub connections") {
-      val endpoint = "tcp://127.0.0.1:%s" format { val s = new java.net.ServerSocket(0); try s.getLocalPort finally s.close() }
-
+      val endpoint = "tcp:/" + SocketUtil.temporaryServerAddress()
       val subscriberProbe = TestProbe()
       val publisher = zmq.newSocket(SocketType.Pub, Bind(endpoint))
       val subscriber = zmq.newSocket(SocketType.Sub, Listener(subscriberProbe.ref), Connect(endpoint), SubscribeAll)
@@ -30,6 +27,7 @@ class ZeroMQExtensionSpec extends TestKit(ActorSystem("ZeroMQExtensionSpec")) wi
       import system.dispatcher
       val msgGenerator = system.scheduler.schedule(100 millis, 10 millis, new Runnable {
         var number = 0
+
         def run() {
           publisher ! Message(ByteString(number.toString), ByteString.empty)
           number += 1
@@ -55,7 +53,7 @@ class ZeroMQExtensionSpec extends TestKit(ActorSystem("ZeroMQExtensionSpec")) wi
     }
 
     it("should support req-rep connections") {
-      val endpoint = "tcp://127.0.0.1:%s" format { val s = new java.net.ServerSocket(0); try s.getLocalPort finally s.close() }
+      val endpoint = "tcp:/" + SocketUtil.temporaryServerAddress()
 
       val requesterProbe = TestProbe()
       val replierProbe = TestProbe()
@@ -79,7 +77,7 @@ class ZeroMQExtensionSpec extends TestKit(ActorSystem("ZeroMQExtensionSpec")) wi
     }
 
     it("should support push-pull connections") {
-      val endpoint = "tcp://127.0.0.1:%s" format { val s = new java.net.ServerSocket(0); try s.getLocalPort finally s.close() }
+      val endpoint = "tcp:/" + SocketUtil.temporaryServerAddress()
 
       val pullerProbe = TestProbe()
       val pusher = zmq.newSocket(SocketType.Push, Bind(endpoint))
@@ -120,4 +118,5 @@ class ZeroMQExtensionSpec extends TestKit(ActorSystem("ZeroMQExtensionSpec")) wi
         actorRef ! Message(ByteString(payload))
     }
   }
+
 }


### PR DESCRIPTION
Provide Java compatibility
Do other related things, including
* Improve readme on dependencies
* Implement Conflate option
* Fix travis build for current jzmq package structure (necessary as one commit because build is broken on trunk)
* Add configurable timeouts and set them liberally for tests (build will not pass on travis otherwise)